### PR TITLE
Improve alt text for key images

### DIFF
--- a/about.html
+++ b/about.html
@@ -195,7 +195,7 @@
                 <h3 class="mb-40">Carrito RAYO INCC</h3>
                 <div class="add_cart_product">
                     <div class="add_cart_product__thumb">
-                        <img src="./assets/img/product/29-3.jpg" alt="">
+                        <img src="./assets/img/product/29-3.jpg" alt="Muñequeras Grip RAYO INCC negras">
                     </div>
                     <div class="add_cart_product__content">
                         <h5><a href="shop.html">Muñequeras Grip RAYO</a></h5>
@@ -205,7 +205,7 @@
                 </div>
                 <div class="add_cart_product">
                     <div class="add_cart_product__thumb">
-                        <img src="./assets/img/product/17.jpg" alt="">
+                        <img src="./assets/img/product/17.jpg" alt="Chaleco Murph 2025 negro">
                     </div>
                     <div class="add_cart_product__content">
                         <h5><a href="shop.html">Chaleco Murph 2025</a></h5>

--- a/contact.html
+++ b/contact.html
@@ -195,7 +195,7 @@
                 <h3 class="mb-40">Carrito RAYO INCC</h3>
                 <div class="add_cart_product">
                     <div class="add_cart_product__thumb">
-                        <img src="./assets/img/product/29-3.jpg" alt="">
+                        <img src="./assets/img/product/29-3.jpg" alt="Muñequeras Grip RAYO INCC negras">
                     </div>
                     <div class="add_cart_product__content">
                         <h5><a href="shop.html">Muñequeras Rayo</a></h5>
@@ -205,7 +205,7 @@
                 </div>
                 <div class="add_cart_product">
                     <div class="add_cart_product__thumb">
-                        <img src="./assets/img/product/17.jpg" alt="">
+                        <img src="./assets/img/product/17.jpg" alt="Chaleco Murph 2025 negro">
                     </div>
                     <div class="add_cart_product__content">
                         <h5><a href="shop.html">Bolso Parches⚡</a></h5>

--- a/eventos.html
+++ b/eventos.html
@@ -195,7 +195,7 @@
                 <h3 class="mb-40">Carrito RAYO INCC</h3>
                 <div class="add_cart_product">
                     <div class="add_cart_product__thumb">
-                        <img src="./assets/img/product/29-3.jpg" alt="">
+                        <img src="./assets/img/product/29-3.jpg" alt="Muñequeras Grip RAYO INCC negras">
                     </div>
                     <div class="add_cart_product__content">
                         <h5><a href="shop.html">Muñequeras Rayo</a></h5>
@@ -205,7 +205,7 @@
                 </div>
                 <div class="add_cart_product">
                     <div class="add_cart_product__thumb">
-                        <img src="./assets/img/product/17.jpg" alt="">
+                        <img src="./assets/img/product/17.jpg" alt="Chaleco Murph 2025 negro">
                     </div>
                     <div class="add_cart_product__content">
                         <h5><a href="shop.html">Bolso Parches⚡</a></h5>

--- a/index.html
+++ b/index.html
@@ -193,8 +193,8 @@
             <div class="cart-text">
                 <h3 class="mb-40">Carrito RAYO INCC</h3>
                 <div class="add_cart_product">
-                    <div class="add_cart_product__thumb">
-                        <img src="./assets/img/product/29-3.jpg" alt="">
+                        <div class="add_cart_product__thumb">
+                            <img src="./assets/img/product/29-3.jpg" alt="Muñequeras Grip RAYO INCC negras">
                     </div>
                     <div class="add_cart_product__content">
                         <h5><a href="shop.html">Muñequeras Grip RAYO</a></h5>
@@ -203,8 +203,8 @@
                     </div>
                 </div>
                 <div class="add_cart_product">
-                    <div class="add_cart_product__thumb">
-                        <img src="./assets/img/product/17.jpg" alt="">
+                        <div class="add_cart_product__thumb">
+                            <img src="./assets/img/product/17.jpg" alt="Chaleco Murph 2025 negro">
                     </div>
                     <div class="add_cart_product__content">
                         <h5><a href="shop.html">Chaleco Murph 2025</a></h5>
@@ -239,20 +239,20 @@
                         <div class="row">
                             <div class="col-xl-5 offset-xl-1 col-lg-5 col-md-5 ">
                                 <div class="left_text text-right">
-                                    <img class="changevalu3" src="./assets/img/slider/slider-shape1.png" alt="">
-                                    <img class="changevalu2" src="./assets/img/slider/slider-dot-shape1.png" alt="">
-                                    <img class="" src="./assets/img/slider/slider-circle-1.png" alt="">
-                                    <img class="common-absoulute changevalue"  src="./assets/img/slider/slider-text1.png" alt="">
+                                    <img class="changevalu3" src="./assets/img/slider/slider-shape1.png" alt="" aria-hidden="true">
+                                    <img class="changevalu2" src="./assets/img/slider/slider-dot-shape1.png" alt="" aria-hidden="true">
+                                    <img class="" src="./assets/img/slider/slider-circle-1.png" alt="" aria-hidden="true">
+                                    <img class="common-absoulute changevalue"  src="./assets/img/slider/slider-text1.png" alt="Texto 'Shoes for Women's' en letras blancas y rojas">
                                 </div>
                             </div>
                             <div class="col-xl-6 col-lg-5 col-md-5">
                                 <div class="righ-images">
-                                    <img class="common-absoulute ab-1 d-none d-sm-block" src="./assets/img/slider/slider-shoe-2.png" alt="">
-                                    <img class="common-absoulute ab-2 d-none d-sm-block" src="./assets/img/slider/slider-shoe-1.png" alt="">
-                                    <img class="common-absoulute ab-3" src="./assets/img/slider/slider-shape2.png" alt="">
-                                    <img class="common-absoulute ab-4" src="./assets/img/slider/slider-shape5.png" alt="">
-                                    <img class="common-absoulute ab-5" src="./assets/img/slider/slider-shape3.png" alt="">
-                                    <img class="common-absoulute ab-6" src="./assets/img/slider/slider-shape1.png" alt="">
+                                    <img class="common-absoulute ab-1 d-none d-sm-block" src="./assets/img/slider/slider-shoe-2.png" alt="Marcador gris con texto 352x475">
+                                    <img class="common-absoulute ab-2 d-none d-sm-block" src="./assets/img/slider/slider-shoe-1.png" alt="Marcador gris con texto 352x475">
+                                    <img class="common-absoulute ab-3" src="./assets/img/slider/slider-shape2.png" alt="" aria-hidden="true">
+                                    <img class="common-absoulute ab-4" src="./assets/img/slider/slider-shape5.png" alt="" aria-hidden="true">
+                                    <img class="common-absoulute ab-5" src="./assets/img/slider/slider-shape3.png" alt="" aria-hidden="true">
+                                    <img class="common-absoulute ab-6" src="./assets/img/slider/slider-shape1.png" alt="" aria-hidden="true">
                                 </div>
                             </div>
                         </div>
@@ -263,18 +263,18 @@
                         <div class="row">
                             <div class="col-xl-5 offset-xl-1 col-lg-5 col-md-5">
                                 <div class="left_text text-right">
-                                    <img class="changevalu3" src="./assets/img/slider/slider-shape1.png" alt="">
-                                    <img class="changevalu2 bottomleft" src="./assets/img/slider/slider-dot-shape1.png" alt="">
-                                    <img class="wow fadeIn" src="./assets/img/slider/slider-square-shape2.jpg" data-wow-delay=".3s" alt="">
-                                    <img class="common-absoulute changevalue"  data-wow-delay=".3s" src="./assets/img/slider/slider-text3.png" alt="">
+                                    <img class="changevalu3" src="./assets/img/slider/slider-shape1.png" alt="" aria-hidden="true">
+                                    <img class="changevalu2 bottomleft" src="./assets/img/slider/slider-dot-shape1.png" alt="" aria-hidden="true">
+                                    <img class="wow fadeIn" src="./assets/img/slider/slider-square-shape2.jpg" data-wow-delay=".3s" alt="" aria-hidden="true">
+                                    <img class="common-absoulute changevalue"  data-wow-delay=".3s" src="./assets/img/slider/slider-text3.png" alt="Texto 'Weekend Sale Jacket' en tipografía blanca y naranja">
                                 </div>
                             </div>
                             <div class="col-xl-6 col-lg-5 col-md-5">
                                 <div class="righ-images pt-200">  
-                                    <img class="common-absoulute ab-3" src="./assets/img/slider/slider-shape2.png" alt="">
-                                    <img class="common-absoulute ab-4" src="./assets/img/slider/slider-shape5.png" alt="">
-                                    <img class="common-absoulute ab-5" src="./assets/img/slider/slider-shape3.png" alt="">
-                                    <img class="common-absoulute ab-6 ab-66" src="./assets/img/slider/slider-shape1.png" alt="">
+                                    <img class="common-absoulute ab-3" src="./assets/img/slider/slider-shape2.png" alt="" aria-hidden="true">
+                                    <img class="common-absoulute ab-4" src="./assets/img/slider/slider-shape5.png" alt="" aria-hidden="true">
+                                    <img class="common-absoulute ab-5" src="./assets/img/slider/slider-shape3.png" alt="" aria-hidden="true">
+                                    <img class="common-absoulute ab-6 ab-66" src="./assets/img/slider/slider-shape1.png" alt="" aria-hidden="true">
                                 </div>
                             </div>
                         </div>
@@ -285,18 +285,18 @@
                         <div class="row">
                             <div class="col-xl-5 offset-xl-1 col-lg-5 col-md-5">
                                 <div class="left_text text-right">
-                                    <img class="changevalu3" src="./assets/img/slider/slider-shape1.png" alt="">
-                                    <img class="changevalu2 bottomleft" src="./assets/img/slider/slider-dot-shape1.png" alt="">
-                                    <img class="" src="./assets/img/slider/slider-square-shape.jpg" data-wow-delay=".3s" alt="">
-                                    <img class="common-absoulute changevalue" src="./assets/img/slider/slider-text2.png" alt="">
+                                    <img class="changevalu3" src="./assets/img/slider/slider-shape1.png" alt="" aria-hidden="true">
+                                    <img class="changevalu2 bottomleft" src="./assets/img/slider/slider-dot-shape1.png" alt="" aria-hidden="true">
+                                    <img class="" src="./assets/img/slider/slider-square-shape.jpg" data-wow-delay=".3s" alt="" aria-hidden="true">
+                                    <img class="common-absoulute changevalue" src="./assets/img/slider/slider-text2.png" alt="Texto 'Jacket for Women's' en mayúsculas blancas y amarillas">
                                 </div>
                             </div>
                             <div class="col-xl-6 col-lg-5 col-md-5">
                                 <div class="righ-images pt-200">
-                                    <img class="common-absoulute ab-3" src="./assets/img/slider/slider-shape2.png" alt="">
-                                    <img class="common-absoulute ab-4" src="./assets/img/slider/slider-shape5.png" alt="">
-                                    <img class="common-absoulute ab-5" src="./assets/img/slider/slider-shape3.png" alt="">
-                                    <img class="common-absoulute ab-6 ab-66" src="./assets/img/slider/slider-shape1.png" alt="">
+                                    <img class="common-absoulute ab-3" src="./assets/img/slider/slider-shape2.png" alt="" aria-hidden="true">
+                                    <img class="common-absoulute ab-4" src="./assets/img/slider/slider-shape5.png" alt="" aria-hidden="true">
+                                    <img class="common-absoulute ab-5" src="./assets/img/slider/slider-shape3.png" alt="" aria-hidden="true">
+                                    <img class="common-absoulute ab-6 ab-66" src="./assets/img/slider/slider-shape1.png" alt="" aria-hidden="true">
                                 </div>
                             </div>
                         </div>
@@ -2110,7 +2110,7 @@
                 <div class="row g-0">
                     <div class="col-xl-4 col-lg-4 col-md-6 col-sm-12">
                         <div class="gallary-image-2 h-100">
-                            <a href="shop.html"><img class="h-100 cover-img" src="./assets/img/gallary/asset51.jpeg" alt=""></a>
+                            <a href="shop.html"><img class="h-100 cover-img" src="./assets/img/gallary/asset51.jpeg" alt="Marcador gris con texto 640x500"></a>
                         </div>
                     </div>
                     <div class="col-xl-4 col-lg-4 col-md-6 col-sm-12 d-md-none d-xl-block">
@@ -2132,7 +2132,7 @@
                     </div>
                     <div class="col-xl-4 col-lg-4 col-md-6 col-sm-12">
                         <div class="gallary-image-2 h-100">
-                            <a href="shop.html"><img class="h-100 cover-img" src="./assets/img/gallary/asset52.jpeg" alt=""></a>
+                            <a href="shop.html"><img class="h-100 cover-img" src="./assets/img/gallary/asset52.jpeg" alt="Marcador gris con texto 640x500"></a>
                         </div>
                     </div>
                 </div>
@@ -2148,7 +2148,7 @@
                     <div class="col-xl-5 col-lg-5 col-md-5">
                         <div class="quickview">
                             <div class="quickview__thumb">
-                                <img src="./assets/img/quick_view/25.jpg" alt="">
+                                <img src="./assets/img/quick_view/25.jpg" alt="Marcador gris con texto 800x800">
                             </div>
                         </div>
                     </div>

--- a/service.html
+++ b/service.html
@@ -195,7 +195,7 @@
                 <h3 class="mb-40">Carrito RAYO INCC</h3>
                 <div class="add_cart_product">
                     <div class="add_cart_product__thumb">
-                        <img src="./assets/img/product/29-3.jpg" alt="">
+                        <img src="./assets/img/product/29-3.jpg" alt="Muñequeras Grip RAYO INCC negras">
                     </div>
                     <div class="add_cart_product__content">
                         <h5><a href="shop.html">Muñequeras Grip RAYO</a></h5>
@@ -205,7 +205,7 @@
                 </div>
                 <div class="add_cart_product">
                     <div class="add_cart_product__thumb">
-                        <img src="./assets/img/product/17.jpg" alt="">
+                        <img src="./assets/img/product/17.jpg" alt="Chaleco Murph 2025 negro">
                     </div>
                     <div class="add_cart_product__content">
                         <h5><a href="shop.html">Chaleco Murph 2025</a></h5>

--- a/shop.html
+++ b/shop.html
@@ -196,7 +196,7 @@
                 <h3 class="mb-40">Carrito RAYO INCC</h3>
                 <div class="add_cart_product">
                     <div class="add_cart_product__thumb">
-                        <img src="./assets/img/product/29-3.jpg" alt="">
+                        <img src="./assets/img/product/29-3.jpg" alt="Muñequeras Grip RAYO INCC negras">
                     </div>
                     <div class="add_cart_product__content">
                         <h5><a href="shop.html">Muñequeras Grip RAYO</a></h5>
@@ -206,7 +206,7 @@
                 </div>
                 <div class="add_cart_product">
                     <div class="add_cart_product__thumb">
-                        <img src="./assets/img/product/17.jpg" alt="">
+                        <img src="./assets/img/product/17.jpg" alt="Chaleco Murph 2025 negro">
                     </div>
                     <div class="add_cart_product__content">
                         <h5><a href="shop.html">Chaleco Murph 2025</a></h5>
@@ -372,16 +372,16 @@
                                         <span>Vistas</span>
                                     </button>
                                     <button class="nav-link active" id="nav-home-tab" data-bs-toggle="tab" data-bs-target="#nav-home" type="button" role="tab" aria-controls="nav-home" aria-selected="true">
-                                        <img src="./assets/img/essential/i2.svg" alt="">
+                                        <img src="./assets/img/essential/i2.svg" alt="Ver productos en cuadrícula de cuatro">
                                     </button>
                                     <button class="nav-link" id="nav-profile-tab" data-bs-toggle="tab" data-bs-target="#nav-profile" type="button" role="tab" aria-controls="nav-profile" aria-selected="false">
-                                        <img src="./assets/img/essential/i3.svg" alt="">
+                                        <img src="./assets/img/essential/i3.svg" alt="Ver productos en cuadrícula de nueve">
                                     </button>
                                     <button class="nav-link" id="nav-contact-tab" data-bs-toggle="tab" data-bs-target="#nav-contact" type="button" role="tab" aria-controls="nav-contact" aria-selected="false">
-                                        <img src="./assets/img/essential/i4.svg" alt="">
+                                        <img src="./assets/img/essential/i4.svg" alt="Ver productos en cuadrícula extendida">
                                     </button>
                                 <button class="nav-link" id="nav-contact-tab2" data-bs-toggle="tab" data-bs-target="#nav-list" type="button" role="tab" aria-controls="nav-contact" aria-selected="false">
-                                    <img src="./assets/img/essential/list.svg" alt="">
+                                    <img src="./assets/img/essential/list.svg" alt="Ver productos en lista">
                                 </button>
                             </div>
                                 </nav>                                 
@@ -2840,7 +2840,7 @@
                                                 <div class="col-xl-4 col-lg-4 col-md-4">
                                                     <div class="list-product">
                                                         <div class="list__thumb">
-                                                            <a href="single.html"><img src="./assets/img/product/23.jpg" alt=""></a>
+                                                            <a href="single.html"><img src="./assets/img/product/23.jpg" alt="Render del bolso Brown Leather Bags"></a>
                                                         </div>
                                                     </div>
                                                 </div>
@@ -2879,7 +2879,7 @@
                                                 <div class="col-xl-4 col-lg-4 col-md-4">
                                                     <div class="list-product">
                                                         <div class="list__thumb">
-                                                            <a href="single.html"><img src="./assets/img/product/8.jpg" alt=""></a>
+                                                            <a href="single.html"><img src="./assets/img/product/8.jpg" alt="Render del calzado Colorful Shoe for Everyone"></a>
                                                         </div>
                                                     </div>
                                                 </div>
@@ -2918,7 +2918,7 @@
                                                 <div class="col-xl-4 col-lg-4 col-md-4">
                                                     <div class="list-product">
                                                         <div class="list__thumb">
-                                                            <a href="single.html"><img src="./assets/img/product/10.jpg" alt=""></a>
+                                                            <a href="single.html"><img src="./assets/img/product/10.jpg" alt="Render del calzado Faxon Canvas Low"></a>
                                                         </div>
                                                     </div>
                                                 </div>
@@ -2957,7 +2957,7 @@
                                                 <div class="col-xl-4 col-lg-4 col-md-4">
                                                     <div class="list-product">
                                                         <div class="list__thumb">
-                                                            <a href="single.html"><img src="./assets/img/product/14.jpg" alt=""></a>
+                                                            <a href="single.html"><img src="./assets/img/product/14.jpg" alt="Render de la franela V-Neck T-Shirt"></a>
                                                         </div>
                                                     </div>
                                                 </div>
@@ -3079,7 +3079,7 @@
                     <div class="col-xl-5 col-lg-5 col-md-5">
                         <div class="quickview">
                             <div class="quickview__thumb">
-                                <img src="./assets/img/quick_view/25.jpg" alt="">
+                                <img src="./assets/img/quick_view/25.jpg" alt="Marcador gris con texto 800x800">
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- provide descriptive alternative text for cart and gallery imagery across the main marketing pages
- mark slider decorations as assistive-technology-hidden while adding descriptions for text-based graphics
- label shop layout icons and product list thumbnails with meaningful alt text

## Testing
- not run (html changes only)


------
https://chatgpt.com/codex/tasks/task_b_68cd707c2fc48322b3e19e7c6cc15e32